### PR TITLE
Fix crash of WC3 and WN3 editors

### DIFF
--- a/WC3Tool/WC3Tool.csproj
+++ b/WC3Tool/WC3Tool.csproj
@@ -6,7 +6,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>WC3Tool</RootNamespace>
+    <RootNamespace>WC3_TOOL</RootNamespace>
     <AssemblyName>WC3Tool</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>


### PR DESCRIPTION
The mentioned editors will crash because the resources of the images that are shown in the editors can't be found. This is due to the root namespace in the project file beeing renamed (missing underscore).
I changed the namespace back to what it was in suloku's file and fixed the crash.